### PR TITLE
Wip/cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 
 # local tests
 local/
+.vscode/launch.json

--- a/README.md
+++ b/README.md
@@ -17,16 +17,42 @@ import (
 )
 
 func main() {
-	fmt.Println("Hello, World!")
+	mo, parser := manout.NewStdColored() // create a new managed and colored output handler instance
 
-	// plain output with colorcodes, what should not work
-	var mo manout.MOut
-	mo.OutLn("hello", manout.ForeCyan, " world", manout.ForeLightGreen, " you should see the colorcodes but no colors ")
-	// now with colored support
-	var coloredParser manout.Colored
-	mo.SetParser(&coloredParser).OutLn("hello", manout.ForeCyan, " world", manout.ForeLightGreen, " now it should work ")
+	// lets loop 2 times
+	for i := 0; i < 2; i++ {
+
+		// in the first loop, the output should be colored
+		// if not, then the stdout is not accepted as a terminal.
+		// this will for exampe happens in launch visual-studio-code jobs.
+		// event they are able to handle the colors.
+		// on any console you should see the first output colored. (bash, zsh, fish, powershell ...)
+		// you can also force color for the first itertion by uncomment the next 3 lines ...
+		//if i == 0 {
+		//	parser.EnableColor()
+		//}
+
+		mo.OutLn(
+			manout.BoldTag, manout.ForeMagenta,
+			"======================================\nhello world ",
+			manout.CleanTag, manout.ForeDarkGrey,
+			" ... you need more ",
+			manout.ForeLightGreen, manout.BackGreen,
+			" GREEN ",
+			manout.CleanTag,
+			"....",
+		)
+		mo.OutLn() // just some space
+
+		// markup used inline. without color, the markup is also removed
+		mo.OutLn(`.... using <b>markup</> <f:yellow>inline</> ... 
+     it is <f:red> NOT </> html. <b:green><f:white>just looks similiar</>`)
+
+		mo.OutLn() // just some space again
+		parser.DisableColor() // disbale color for the next loop
+	}
 
 }
 ```
 ### output
-![example output](https://github.com/swaros/docu-asset-store/blob/main/demo-manout.png)
+![example output](https://github.com/swaros/docu-asset-store/blob/main/manout-demo2.png)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/swaros/manout
 
 go 1.17
+
+require (
+	golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c // indirect
+	golang.org/x/term v0.0.0-20220526004731-065cf7ba2467
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c h1:aFV+BgZ4svzjfabn8ERpuB4JI4N6/rdy1iusx77G3oU=
+golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20220526004731-065cf7ba2467 h1:CBpWXWQpIRjzmkkA+M7q9Fqnwd2mZr3AFqexg8YTfoM=
+golang.org/x/term v0.0.0-20220526004731-065cf7ba2467/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/manout.go
+++ b/manout.go
@@ -44,6 +44,11 @@ type MOut struct {
 	parser      OutParser
 }
 
+func NewStdout() *MOut {
+	var m MOut
+	return m.Std()
+}
+
 // set stdout as writer
 func (m *MOut) Std() *MOut {
 	m.io = os.Stdout

--- a/manout.go
+++ b/manout.go
@@ -1,3 +1,25 @@
+/*MIT License
+
+Copyright (c) 2022 Thomas Ziegler, <thomas.zglr@googlemail.com>. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
 package manout
 
 import (
@@ -6,10 +28,12 @@ import (
 	"os"
 )
 
+// list of writers accessible by the keyname
 var (
 	writers map[string]io.Writer = make(map[string]io.Writer)
 )
 
+// interface for parsers
 type OutParser interface {
 	Message(i ...interface{}) string
 }
@@ -20,21 +44,27 @@ type MOut struct {
 	parser      OutParser
 }
 
+// set stdout as writer
 func (m *MOut) Std() *MOut {
 	m.io = os.Stdout
 	return m
 }
 
+// set stderr as writer
 func (m *MOut) Err() *MOut {
 	m.io = os.Stderr
 	return m
 }
 
+// sets the parser they is responsible for formatting
 func (m *MOut) SetParser(parser OutParser) *MOut {
 	m.parser = parser
 	return m
 }
 
+// sets an named writer if exists.
+// or ignores if not.
+// writer have to be set with SetNamedWriter before.
 func (m *MOut) Named(key string) *MOut {
 	if io, exists := writers[key]; exists {
 		m.io = io
@@ -43,6 +73,8 @@ func (m *MOut) Named(key string) *MOut {
 	return m
 }
 
+// register or overidde a io.Writer by key-name.
+// also it will be set as the current writer
 func (m *MOut) SetNamedWriter(key string, io io.Writer) *MOut {
 	if key == "" {
 		key = "default"
@@ -53,6 +85,7 @@ func (m *MOut) SetNamedWriter(key string, io io.Writer) *MOut {
 	return m
 }
 
+// ToString get the formated string, depending on the used formatter
 func (m *MOut) ToString(i ...interface{}) string {
 	if m.parser == nil {
 		var plain PlainParse
@@ -62,18 +95,22 @@ func (m *MOut) ToString(i ...interface{}) string {
 
 }
 
-func (m *MOut) Out(i ...interface{}) {
+// Out print the formatted content by using fmt.Fprint
+// have the same return values.
+func (m *MOut) Out(i ...interface{}) (n int, err error) {
 	out := m.ToString(i...)
 	if m.io == nil {
 		m.Std()
 	}
-	fmt.Fprint(m.io, out)
+	return fmt.Fprint(m.io, out)
 }
 
-func (m *MOut) OutLn(i ...interface{}) {
+// OutLn print the formatted content by using fmt.Fprintln
+// it have the same return values like fmt.Fprintln
+func (m *MOut) OutLn(i ...interface{}) (n int, err error) {
 	out := m.ToString(i...)
 	if m.io == nil {
 		m.Std()
 	}
-	fmt.Fprintln(m.io, out)
+	return fmt.Fprintln(m.io, out)
 }

--- a/parseplain.go
+++ b/parseplain.go
@@ -8,3 +8,7 @@ type PlainParse struct {
 func (c PlainParse) Message(i ...interface{}) string {
 	return fmt.Sprint(i...)
 }
+
+func (c PlainParse) Enable(mo *MOut) bool {
+	return true
+}

--- a/parsercolored.go
+++ b/parsercolored.go
@@ -9,11 +9,16 @@ type Colored struct {
 	enabled bool
 }
 
+func (c *Colored) Enable(mo *MOut) bool {
+	c.enabled = mo.isTerminal
+	return c.enabled
+}
+
 func (c *Colored) Message(i ...interface{}) string {
 	stringResult := fmt.Sprint(i...)
 	needToDo := strings.Contains(stringResult, "<")
 	if needToDo {
-		replaceed := buildColored(stringResult)
+		replaceed := c.buildColored(stringResult)
 		return replaceed
 	}
 	return stringResult
@@ -25,4 +30,28 @@ func (c *Colored) DisableColor() {
 
 func (c *Colored) EnableColor() {
 	c.enabled = true
+}
+
+func (c *Colored) buildColored(origin string) string {
+
+	for key, code := range tagMap {
+		colCde := "\033[" + code + "m"
+		if !c.enabled {
+			colCde = ""
+		}
+		if strings.Contains(origin, key) {
+			origin = strings.ReplaceAll(origin, key, colCde)
+		}
+
+		if strings.Contains(origin, CleanTag) {
+			if !c.enabled {
+				origin = strings.ReplaceAll(origin, CleanTag, "")
+			} else {
+				origin = strings.ReplaceAll(origin, CleanTag, resetCode)
+			}
+		}
+
+	}
+
+	return origin
 }


### PR DESCRIPTION
- adds terminal detection support. new requirement:  golang.org/x/term
 - rework of example code.
 - adds Enable Hook
 - adds GetParser Getter
 - duplicate markup-parser func from outputhandler to manout (part of cleanup)
